### PR TITLE
Use associated types on the enum for image.

### DIFF
--- a/Example/SAConfettiView/ViewController.swift
+++ b/Example/SAConfettiView/ViewController.swift
@@ -39,7 +39,7 @@ class ViewController: UIViewController {
         confettiView.type = .Diamond
         
         // For custom image
-        // confettiView.type = .Custom(UIImage(named: "diamond")!)
+        // confettiView.type = .Image(UIImage(named: "diamond")!)
         
         // Add subview
         view.addSubview(confettiView)

--- a/Example/SAConfettiView/ViewController.swift
+++ b/Example/SAConfettiView/ViewController.swift
@@ -39,8 +39,7 @@ class ViewController: UIViewController {
         confettiView.type = .Diamond
         
         // For custom image
-        // confettiView.type = .Custom
-        // confettiView.customImage = UIImage(named: "diamond")
+        // confettiView.type = .Custom(UIImage(named: "diamond")!)
         
         // Add subview
         view.addSubview(confettiView)

--- a/Pod/Classes/SAConfettiView.swift
+++ b/Pod/Classes/SAConfettiView.swift
@@ -16,7 +16,7 @@ public class SAConfettiView: UIView {
         case Triangle
         case Star
         case Diamond
-        case Custom(UIImage)
+        case Image(UIImage)
     }
 
     var emitter: CAEmitterLayer!
@@ -72,7 +72,7 @@ public class SAConfettiView: UIView {
             fileName = "star"
         case .Diamond:
             fileName = "diamond"
-        case let .Custom(customImage):
+        case let .Image(customImage):
             return customImage
         }
         

--- a/Pod/Classes/SAConfettiView.swift
+++ b/Pod/Classes/SAConfettiView.swift
@@ -16,14 +16,13 @@ public class SAConfettiView: UIView {
         case Triangle
         case Star
         case Diamond
-        case Custom
+        case Custom(UIImage)
     }
 
     var emitter: CAEmitterLayer!
     public var colors: [UIColor]!
     public var intensity: Float!
     public var type: ConfettiType!
-    public var customImage: UIImage?
     
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
@@ -73,7 +72,7 @@ public class SAConfettiView: UIView {
             fileName = "star"
         case .Diamond:
             fileName = "diamond"
-        case .Custom:
+        case let .Custom(customImage):
             return customImage
         }
         


### PR DESCRIPTION
This PR removes the `customImage` property in favor of using the `ConfettiType` enum itself; the `Custom` case has an associated `UIImage` that we use.