### PR TITLE
Swift 4.2: `kCAEmitterLayerLine` has been renamed to `CAEmitterLayerEmitterShape.line`

### DIFF
--- a/Pod/Classes/SAConfettiView.swift
+++ b/Pod/Classes/SAConfettiView.swift
@@ -50,7 +50,7 @@ public class SAConfettiView: UIView {
         emitter = CAEmitterLayer()
 
         emitter.emitterPosition = CGPoint(x: frame.size.width / 2.0, y: 0)
-        emitter.emitterShape = kCAEmitterLayerLine
+        emitter.emitterShape = .line
         emitter.emitterSize = CGSize(width: frame.size.width, height: 1)
 
         var cells = [CAEmitterCell]()


### PR DESCRIPTION
In comparison to Swift 4.1 `kCAEmitterLayerLine` has been renamed to `CAEmitterLayerEmitterShape.line` in Swift 4.2.